### PR TITLE
Feature/login with flow

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,4 +1,4 @@
 ext {
     kotlin_version = '1.3.70'
-    coroutineVersion = '1.3.6'
+    coroutineVersion = '1.3.7'
 }

--- a/features/login/src/main/java/com/can_apps/login/bresenter/LoginEvents.kt
+++ b/features/login/src/main/java/com/can_apps/login/bresenter/LoginEvents.kt
@@ -1,3 +1,4 @@
 package com.can_apps.login.bresenter
 
 internal data class OnPasswordChangedEvent(val value: String)
+internal data class OnLoginChangedEvent(val value: String)

--- a/features/login/src/main/java/com/can_apps/login/bresenter/LoginPresenter.kt
+++ b/features/login/src/main/java/com/can_apps/login/bresenter/LoginPresenter.kt
@@ -33,14 +33,13 @@ internal class LoginPresenter(
     private val passwordChannel = Channel<OnPasswordChangedEvent>(Channel.CONFLATED)
 
     //TODO discuss the issue with Canato
-    private val _loginFlow: MutableStateFlow<OnLoginChangedEvent> = MutableStateFlow(OnLoginChangedEvent(" "))
+    private val _loginFlow: MutableStateFlow<OnLoginChangedEvent> = MutableStateFlow(OnLoginChangedEvent(""))
     private val loginFlow: StateFlow<OnLoginChangedEvent>
         get() = _loginFlow
 
     override fun bind(view: LoginContract.View) {
         this.view = view
         verifyPassword(passwordChannel)
-        verifyLogin(loginFlow)
     }
 
     override fun unbind() {
@@ -75,6 +74,7 @@ internal class LoginPresenter(
 
     override fun onLoginInputChanged(login: String) {
         _loginFlow.value = OnLoginChangedEvent(login)
+        verifyLogin(loginFlow)
     }
 
     override fun onPasswordInputChanged(password: String) {

--- a/features/login/src/main/java/com/can_apps/login/bresenter/LoginPresenter.kt
+++ b/features/login/src/main/java/com/can_apps/login/bresenter/LoginPresenter.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 
@@ -28,7 +30,6 @@ internal class LoginPresenter(
         get() = dispatcher.UI + job
 
     private val passwordChannel = Channel<OnPasswordChangedEvent>(Channel.CONFLATED)
-    //todo tomasz, create the same behaviour for LoginName with Flow
 
     override fun bind(view: LoginContract.View) {
         this.view = view
@@ -45,7 +46,9 @@ internal class LoginPresenter(
         updateButtonsFunction(loginValid && passwordValid)
     }
 
-    override fun onBackPressed() { view?.close() }
+    override fun onBackPressed() {
+        view?.close()
+    }
 
     override fun onSignClicked(loginName: String, password: String) {
         signInUser(loginName, password)
@@ -55,18 +58,28 @@ internal class LoginPresenter(
         createNewUser(loginName, password)
     }
 
-    override fun logoutUser() { logout() }
+    override fun logoutUser() {
+        logout()
+    }
 
-    override fun checkLogIn() { checkLogInStatus() }
+    override fun checkLogIn() {
+        checkLogInStatus()
+    }
 
-    override fun onLoginInputChanged(login: String) { verifyLogin(login) }
+    override fun onLoginInputChanged(login: String) {
+        verifyLogin(generateFlow(login))
+    }
 
     override fun onPasswordInputChanged(password: String) {
         passwordChannel.offer(OnPasswordChangedEvent(password))
     }
 
-    private fun CoroutineScope.verifyLogin(login: String) = launch(dispatcher.IO) {
-        when (val domain = interactor.loginNameValidation(LoginNameDomain(login))) {
+    private fun generateFlow(login: String): Flow<OnLoginChangedEvent>
+        = flow { emit(OnLoginChangedEvent(login)) }
+
+    private fun CoroutineScope.verifyLogin(flow: Flow<OnLoginChangedEvent>) = launch(dispatcher.IO) {
+        flow.conflate().collect{
+        when (val domain = interactor.loginNameValidation(LoginNameDomain(it.value))) {
             is LoginNameValidationDomain.Valid -> {
                 checkLoginBox(true)
                 updateLoginView(null)
@@ -81,15 +94,16 @@ internal class LoginPresenter(
                 updateButtonsFunction(loginValid && passwordValid)
             }
         }
-    }
+    }}
 
     private fun CoroutineScope.verifyPassword(
         receiveChannel: ReceiveChannel<OnPasswordChangedEvent>
     ) = launch(dispatcher.IO) {
         for (event in receiveChannel) {
-            when(event) {
+            when (event) {
                 is OnPasswordChangedEvent -> {
-                    when (val domain = interactor.passwordValidation(LoginPasswordDomain(event.value))) {
+                    when (val domain =
+                        interactor.passwordValidation(LoginPasswordDomain(event.value))) {
                         is LoginPasswordValidationDomain.Valid -> {
                             checkPasswordBox(true)
                             updatePasswordView(null)
@@ -105,7 +119,8 @@ internal class LoginPresenter(
                         }
                     }
                 }
-                else -> { } //do nothing
+                else -> {
+                } //do nothing
             }
         }
     }
@@ -120,7 +135,9 @@ internal class LoginPresenter(
                     showSuccess()
                     cleanInputViews()
                 }
-                is LoginDomain.Fail -> {showError(result.error.value)}
+                is LoginDomain.Fail -> {
+                    showError(result.error.value)
+                }
             }
         }
 
@@ -148,7 +165,9 @@ internal class LoginPresenter(
 
     private fun CoroutineScope.checkLogInStatus() = launch(dispatcher.IO) {
         when (val result = interactor.checkLogInStatus()) {
-            is LoginDomain.Success -> {showLogInStatus(stringResource.getString(R.string.sign_in_true)) }
+            is LoginDomain.Success -> {
+                showLogInStatus(stringResource.getString(R.string.sign_in_true))
+            }
             is LoginDomain.Fail -> showLogInStatus(result.error.value)
         }
     }
@@ -175,9 +194,10 @@ internal class LoginPresenter(
         view?.updateLoginTextViewErrorMessage(message)
     }
 
-    private fun CoroutineScope.updatePasswordView(message: LoginModel.Error?) = launch(dispatcher.UI) {
-        view?.updatePasswordTextViewErrorMessage(message)
-    }
+    private fun CoroutineScope.updatePasswordView(message: LoginModel.Error?) =
+        launch(dispatcher.UI) {
+            view?.updatePasswordTextViewErrorMessage(message)
+        }
 
     private fun CoroutineScope.updateButtonsFunction(enable: Boolean) = launch(dispatcher.UI) {
         when (enable) {

--- a/features/login/src/test/java/com/can_apps/login/bresenter/LoginPresenterTest.kt
+++ b/features/login/src/test/java/com/can_apps/login/bresenter/LoginPresenterTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 internal class LoginPresenterTest {
 
     @MockK
@@ -33,7 +34,6 @@ internal class LoginPresenterTest {
     @InjectMockKs
     private lateinit var presenter: LoginPresenter
 
-    @ExperimentalCoroutinesApi
     @Before
     fun setup() {
         MockKAnnotations.init(this, relaxed = true)


### PR DESCRIPTION
Documentation of usage state flow instead of flow: 
https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/index.html

In shortcut - flow cannot be updated, it will just whole given data in one chunk from stream. To value be updated and react as Broadcast Channel we need to use StateFlow.

Current issue - with implemented initial variable, it wont pass empty login test -> value wont be changed, so it wont start the flow update.
So temporarly i made value for as a space (annotated TODO) -> to allow pass the tests. But is to discuss how to resolve it